### PR TITLE
Fix missing include file

### DIFF
--- a/src/source/libnu.cpp
+++ b/src/source/libnu.cpp
@@ -11,8 +11,9 @@
 
 #if defined(__APPLE__)
 #include <malloc/malloc.h>
-#elif defined(linux)
+#else
 #include <malloc.h>
+#include <sys/time.h>
 #endif
 
 #include <cstddef>


### PR DESCRIPTION
The `<sys/time.h>` header file is missing and causes the build to fail on Linux (Tesla).

```
src/source/libnu.cpp: In function ‘void initialize_me()’:
src/source/libnu.cpp:114:22: error: aggregate ‘initialize_me()::itimerval tm’ has incomplete type and cannot be defined
  114 |     struct itimerval tm;
      |                      ^~
src/source/libnu.cpp:119:15: error: ‘ITIMER_REAL’ was not declared in this scope
  119 |     setitimer(ITIMER_REAL, &tm, nullptr);
      |               ^~~~~~~~~~~
src/source/libnu.cpp:119:5: error: ‘setitimer’ was not declared in this scope
  119 |     setitimer(ITIMER_REAL, &tm, nullptr);
      |     ^~~~~~~~~
```

Also, it seems `defined(linux)` does not evaluate to true.